### PR TITLE
Update FMFramework/FMMoveTableView.m

### DIFF
--- a/FMFramework/FMMoveTableView.m
+++ b/FMFramework/FMMoveTableView.m
@@ -349,7 +349,9 @@
 									 }
 									 
 									 // Reload row at moving index path to reset it's content
-									 NSIndexPath *movingIndexPath = [self movingIndexPath];
+									 
+                                                                         NSIndexPath *movingIndexPath = [NSIndexPath indexPathForRow:[self movingIndexPath].row
+                                                                                                                           inSection:[self movingIndexPath].section];
 									 [self setMovingIndexPath:nil];
 									 [self setInitialIndexPathForMovingRow:nil];
 									 [self reloadRowsAtIndexPaths:[NSArray arrayWithObject:movingIndexPath] withRowAnimation:UITableViewRowAnimationNone];


### PR DESCRIPTION
(in handleLongPress: function)

'NSIndexPath *movingIndexPath = ...' seems to reference nil object after [self setMovingIndexPath:nil] called.

It crashes on following [self reloadRowsAtIndexPaths: withRowAnimation:] in my environment(Xcode 4.5, iPhone Simulator 6.0, NON-ARC),

so I fixed it to create a new NSIndexPath from the old one.
