### PR TITLE
- (void)prepareForMove method now works for custom UITableViewCells

### DIFF
--- a/FMFramework/FMMoveTableViewCell.m
+++ b/FMFramework/FMMoveTableViewCell.m
@@ -14,9 +14,10 @@
 
 - (void)prepareForMove
 {
-	[[self textLabel] setText:@""];
-	[[self detailTextLabel] setText:@""];
-	[[self imageView] setImage:nil];
+	UIView *coverView = [[UIView alloc] initWithFrame:self.contentView.frame];
+	coverView.backgroundColor = [UIColor whiteColor];
+	
+	[self.contentView addSubview:coverView];
 }
 
 


### PR DESCRIPTION
In the past, custom cells that don't use the properties `textLabel`, `detailTextLabel`, etc. or those that had a custom background color would remain visible when picked up (to move). I changed the FMMoveTableViewCell's `- (void)prepareForMove` method to work even for such cells.
