### PR TITLE
Added flag to require ARC in podspec

### DIFF
--- a/FMMoveTableView.podspec
+++ b/FMMoveTableView.podspec
@@ -9,4 +9,5 @@ Pod::Spec.new do |s|
   s.platform = :ios
   s.source_files = 'FMFramework/*.{h,m}'
   s.frameworks   = 'QuartzCore'
+  s.requires_arc = true
 end


### PR DESCRIPTION
The podspec should specifically require ARC, otherwise this framework will leak when using Cocoapods
