### PR TITLE
Fixed warning in iOS 8.

### DIFF
--- a/FMFramework/FMMoveTableView.m
+++ b/FMFramework/FMMoveTableView.m
@@ -331,10 +331,18 @@
     FMMoveTableViewCell *touchedCell = (FMMoveTableViewCell *)[self cellForRowAtIndexPath:self.movingIndexPath];
     touchedCell.selected = NO;
     touchedCell.highlighted = NO;
-
+    
+    
+    //Create a snap shot as below and not as(image empty issue and snap shot warning was shown in iOS 8)
+        
+    UIGraphicsBeginImageContextWithOptions(touchedCell.bounds.size, NO, 0);
+    [touchedCell.layer renderInContext:UIGraphicsGetCurrentContext()];
+    UIImage *cellImage = UIGraphicsGetImageFromCurrentImageContext();
+    UIGraphicsEndImageContext();
+    
     [touchedCell prepareForMoveSnapshot];
     
-    UIView *snapshot = [touchedCell snapshotViewAfterScreenUpdates:YES];
+    UIView *snapshot =  [[UIImageView alloc] initWithImage:cellImage];
     snapshot.frame = touchedCell.frame;
     snapshot.alpha = 0.95;
     snapshot.layer.shadowOpacity = 0.7;

--- a/FMMoveTable/Info.plist
+++ b/FMMoveTable/Info.plist
@@ -25,7 +25,7 @@
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>174</string>
+	<string>175</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UILaunchStoryboardName</key>


### PR DESCRIPTION
Fixed this warning : "Snapshotting a view that has not been rendered
results in an empty snapshot. Ensure your view has been rendered at
least once before snapshotting or snapshot after screen updates."